### PR TITLE
Fixed login exception in Docker

### DIFF
--- a/src/main/java/com/uniovi/controllers/OperatorController.java
+++ b/src/main/java/com/uniovi/controllers/OperatorController.java
@@ -25,7 +25,7 @@ public class OperatorController extends AppController{
 	
 	@RequestMapping("/login")
 	public String getLogin() {
-		return "/login";
+		return "login";
 	}
 
 	@RequestMapping("/incidents")


### PR DESCRIPTION
Fixed a problem where an exception was raised when accessing "/login" if the Dashboard was run inside a Docker container.

It appears that Docker can't access resources that start with a '/'. This happens with templates, css and scripts. So although the previous code worked when running the dashboard outside a container, it threw an exception if it was run inside a container.

Now everything works fine both inside and outside a container.